### PR TITLE
feat(app): Complete ABCI interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,74 +58,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "bcs"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b06b4c1f053002b70e7084ac944c77d58d5d92b2110dbc5e852735e00ad3ccc"
+checksum = "4bd3ffe8b19a604421a5d461d4a70346223e535903fbc3067138bddbebddcf77"
 dependencies = [
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -288,12 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,26 +248,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -373,12 +295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
-
-[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,15 +326,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "erased-serde"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "errno"
@@ -453,20 +360,11 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]
@@ -475,7 +373,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
- "eyre",
  "paste",
 ]
 
@@ -602,31 +499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "h2"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,128 +520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "http"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hyper"
-version = "0.14.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "ibc"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa217b0a0c2f802d62da15e8d8380d28d4a7b1affcf5c494266c618508999de3"
-dependencies = [
- "bytes",
- "derive_more",
- "dyn-clone",
- "erased-serde",
- "flex-error",
- "ibc-proto",
- "ics23",
- "num-traits",
- "primitive-types",
- "prost",
- "safe-regex",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "subtle-encoding",
- "tendermint 0.26.0",
- "tendermint-light-client-verifier",
- "tendermint-proto 0.26.0",
- "time",
- "tracing",
- "uint",
-]
-
-[[package]]
-name = "ibc-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874af3f9f3fe1a3458e54b1d4ebb2ab1fadc22b02470eb2d623a59f3c7d907c0"
-dependencies = [
- "base64",
- "bytes",
- "flex-error",
- "prost",
- "serde",
- "subtle-encoding",
- "tendermint-proto 0.26.0",
- "tonic",
-]
-
-[[package]]
 name = "ics23"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,29 +535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "instant"
@@ -990,12 +721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,12 +748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,14 +755,14 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1100,19 +819,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -1167,36 +877,26 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "penumbra-storage"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/penumbra?branch=main#5198cd83e868333acb32565d93a3de3f97fab52f"
+source = "git+https://github.com/penumbra-zone/penumbra?branch=main#74d703297194efc5cabf05c8c088fca0049e28e9"
 dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "bincode",
  "futures",
  "hex",
- "ibc",
- "ibc-proto",
  "ics23",
  "jmt",
  "metrics",
- "once_cell",
  "parking_lot",
+ "pin-project",
  "rocksdb",
- "sha2 0.9.9",
+ "smallvec",
  "tempfile",
- "tendermint 0.26.0",
+ "tendermint",
  "tokio",
  "tokio-stream",
- "tonic",
  "tracing",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
@@ -1264,17 +964,6 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
-dependencies = [
- "fixed-hash",
- "impl-serde",
- "uint",
 ]
 
 [[package]]
@@ -1389,14 +1078,23 @@ dependencies = [
  "eyre",
  "penumbra-storage",
  "pulzaar-chain",
- "tendermint 0.28.0",
+ "pulzaar-encoding",
+ "tendermint",
+ "tracing",
 ]
 
 [[package]]
 name = "pulzaar-chain"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "eyre",
+ "hex",
+ "penumbra-storage",
+ "pulzaar-encoding",
  "serde",
+ "sha2 0.10.6",
+ "tendermint",
 ]
 
 [[package]]
@@ -1415,6 +1113,7 @@ dependencies = [
  "rand",
  "serde",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 
@@ -1450,8 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "radicle-cli-test"
-version = "0.1.0"
-source = "git+https://github.com/xla/heartwood?branch=xla/extract-testing-crate#97f7064094d97ae694ce926d310cf7db6ec4a9e0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df187ee120e2dfc949bfae6b1acbe8b8d815167ba5229a312cdabfeb4952bc27"
 dependencies = [
  "log",
  "pretty_assertions",
@@ -1578,12 +1278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
-
-[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,53 +1294,6 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "safe-proc-macro2"
-version = "1.0.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814c536dcd27acf03296c618dab7ad62d28e70abd7ba41d3f34a2ce707a2c666"
-dependencies = [
- "unicode-xid 0.2.4",
-]
-
-[[package]]
-name = "safe-quote"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
-dependencies = [
- "safe-proc-macro2",
-]
-
-[[package]]
-name = "safe-regex"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15289bf322e0673d52756a18194167f2378ec1a15fe884af6e2d2cb934822b0"
-dependencies = [
- "safe-regex-macro",
-]
-
-[[package]]
-name = "safe-regex-compiler"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba76fae590a2aa665279deb1f57b5098cbace01a0c5e60e262fcf55f7c51542"
-dependencies = [
- "safe-proc-macro2",
- "safe-quote",
-]
-
-[[package]]
-name = "safe-regex-macro"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c2e96b5c03f158d1b16ba79af515137795f4ad4e8de3f790518aae91f1d127"
-dependencies = [
- "safe-proc-macro2",
- "safe-regex-compiler",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1753,9 +1400,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -1789,9 +1436,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snapbox"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34eced5a65e76d5a00047986a83c65f80dc666faa27b5138f331659e2ca6bcf5"
+checksum = "060eb131099764cd2ac39ebba5f56457dde50f0812ffbe0ac1fd7844de0a1a12"
 dependencies = [
  "concolor",
  "normalize-line-endings",
@@ -1815,12 +1462,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1858,12 +1499,6 @@ dependencies = [
  "quote 1.0.23",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -1915,50 +1550,9 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.26.0",
+ "tendermint-proto",
  "time",
  "zeroize",
-]
-
-[[package]]
-name = "tendermint"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c518c082146825f10d6f9a32159ae46edcfd7dae8ac630c8067594bb2a784d72"
-dependencies = [
- "bytes",
- "ed25519",
- "ed25519-dalek",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.9.9",
- "signature",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.28.0",
- "time",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint-light-client-verifier"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66e3e75f9be6260fab5d5c9a6688885c478c3d3a14c66c2fde80c78769c20ee"
-dependencies = [
- "derive_more",
- "flex-error",
- "serde",
- "tendermint 0.26.0",
- "time",
 ]
 
 [[package]]
@@ -1966,24 +1560,6 @@ name = "tendermint-proto"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "974d6330a19dfa6720e9f663fc59101d207a817db3f9c730d3f31caaa565b574"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890f1fb6dee48900c85f0cdf711ebf130e505ac09ad918cee5c34ed477973b05"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2019,13 +1595,10 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
 dependencies = [
- "libc",
- "num_threads",
- "serde",
  "time-core",
  "time-macros",
 ]
@@ -2038,9 +1611,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -2067,16 +1640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,110 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6a3b08b64e6dfad376fa2432c7b1f01522e37a623c3050bc95db2d3ff21583"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "prost-derive",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "pin-project",
- "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2229,38 +1694,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unarray"
@@ -2311,16 +1748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
 ]
 
 [[package]]
@@ -2440,9 +1867,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bcs               = { version = "0.1",  default-features = false }
 dialoguer         = { version = "0.10", default-features = false }
 eyre              = { version = "0.6",  default-features = false }
 futures           = { version = "0.3",  default-features = false }
+hex               = { version = "0.4",  default-features = false }
 lexopt            = { version = "0.3",  default-features = false }
 log               = { version = "0.4",  default-features = false }
 penumbra-storage  = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
@@ -22,16 +23,20 @@ pretty_assertions = { version = "1.3",  default-features = false }
 radicle-cli-test  = { version = "0.1" }
 rand              = { version = "0.8",  default-features = false }
 serde             = { version = "1.0",  default-features = false }
+sha2              = { version = "0.10", default-features = false }
 shlex             = { version = "1.1",  default-features = false }
 snapbox           = { version = "0.4",  default-features = false }
 tempfile          = { version = "3.3",  default-features = false }
-tendermint        = { version = "0.28", default-features = false }
+tendermint        = { version = "0.26", default-features = false }
 thiserror         = { version = "1.0",  default-features = false }
 tokio             = { version = "1.25", default-features = false }
+tracing           = { version = "0.1",  default-features = false }
 
 [workspace.package]
-authors     = ["Pulzaar Team <core@pulzaar.zone>"]
-edition     = "2021"
-homepage    = "https://pulzaar.zone"
-repository  = "https://github.com/pulzaar-zone/pulzaar"
-publish     = false
+authors       = ["Pulzaar Team <core@pulzaar.zone>"]
+edition       = "2021"
+license       = "MIT or Apache-2.0"
+homepage      = "https://pulzaar.zone"
+repository    = "https://github.com/pulzaar-zone/pulzaar"
+rust-version  = "1.67"
+publish       = false

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name                  = "pulzaar-app"
 version               = "0.1.0"
-authors.workspace     = true
-edition.workspace     = true
-homepage.workspace    = true
-repository.workspace  = true
-publish.workspace     = true
+authors.workspace       = true
+edition.workspace       = true
+repository.workspace    = true
+homepage.workspace      = true
+license.workspace       = true
+rust-version.workspace  = true
+publish.workspace       = true
 
 [dependencies]
 pulzaar-chain     = { path = "../chain" }
+pulzaar-encoding  = { path = "../encoding" }
 
 async-trait       = { workspace = true }
 eyre              = { workspace = true }
 penumbra-storage  = { workspace = true }
 tendermint        = { workspace = true }
+tracing           = { workspace = true }

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -1,32 +1,136 @@
 use std::sync::Arc;
 
-use penumbra_storage::State;
-use pulzaar_chain::genesis::AppState;
+use penumbra_storage::{ArcStateDeltaExt as _, Snapshot, StateDelta, Storage};
+use pulzaar_chain::{genesis::AppState, AppHash, StateWriteExt as _, Transaction};
+use pulzaar_encoding as encoding;
+use tendermint::{
+    abci::{self, request, types::ValidatorUpdate},
+    consensus::Params,
+};
+use tracing::instrument;
 
-use crate::Component;
+use crate::{
+    component::{ABCIComponent as _, Component},
+    handler::Handler as _,
+};
 
 /// The Pulzaar ABCI application modeled as stack of [`Component`]s.
 pub struct App {
-    components: Vec<Box<dyn Component>>,
-    state: Arc<State>,
+    components: Vec<Component>,
+    state: Arc<StateDelta<Snapshot>>,
 }
 
 impl App {
-    pub fn new(state: State) -> Self {
+    pub fn new(snapshot: Snapshot) -> Self {
         Self {
             components: vec![],
-            state: Arc::new(state),
+            state: Arc::new(StateDelta::new(snapshot)),
         }
     }
 
+    #[instrument(skip(self, app_state))]
     pub async fn init_chain(&mut self, app_state: &AppState) {
-        let state = Arc::get_mut(&mut self.state).expect("failed to acquire state reference");
-        let mut state_tx = state.begin_transaction();
+        let mut state_tx = self
+            .state
+            .try_begin_transaction()
+            .expect("state Arc should not be referenced elsewhere");
 
         for component in &self.components {
-            component.init_chain(&mut state_tx, app_state).await;
+            match component {
+                Component::Staking(cmp) => cmp.init_chain(&mut state_tx, app_state).await,
+            }
         }
 
         state_tx.apply();
+    }
+
+    #[instrument(skip(self, begin_block))]
+    pub async fn begin_block(&mut self, begin_block: &request::BeginBlock) -> Vec<abci::Event> {
+        let mut state_tx = self
+            .state
+            .try_begin_transaction()
+            .expect("state Arc should not be referenced elsewhere");
+
+        // store the block height
+        let _ = state_tx.put_block_height(begin_block.header.height.into());
+        // store the block time
+        let _ = state_tx.put_block_timestamp(begin_block.header.time);
+
+        for component in &self.components {
+            match component {
+                Component::Staking(cmp) => cmp.begin_block(&mut state_tx, begin_block).await,
+            }
+        }
+
+        state_tx.apply().1
+    }
+
+    #[instrument(skip(self, tx))]
+    pub async fn deliver_tx(&mut self, tx: Transaction) -> eyre::Result<Vec<abci::Event>> {
+        let tx = Arc::new(tx);
+        tx.validate(tx.clone()).await?;
+        tx.check(self.state.clone()).await?;
+
+        let mut state_tx = self
+            .state
+            .try_begin_transaction()
+            .expect("state Arc should not be referenced elsewhere");
+        tx.execute(&mut state_tx).await?;
+
+        Ok(state_tx.apply().1)
+    }
+
+    #[instrument(skip(self, tx_bytes))]
+    pub async fn deliver_tx_bytes(&mut self, tx_bytes: &[u8]) -> eyre::Result<Vec<abci::Event>> {
+        let tx: Transaction = encoding::from_bytes(tx_bytes)?;
+        self.deliver_tx(tx).await
+    }
+
+    #[instrument(skip(self))]
+    pub async fn end_block(
+        &mut self,
+        end_block: &request::EndBlock,
+    ) -> (Vec<ValidatorUpdate>, Option<Params>, Vec<abci::Event>) {
+        let mut state_tx = self
+            .state
+            .try_begin_transaction()
+            .expect("state Arc should not be referenced elsewhere");
+
+        for component in &self.components {
+            match component {
+                Component::Staking(cmp) => cmp.end_block(&mut state_tx, end_block).await,
+            }
+        }
+
+        let events = state_tx.apply().1;
+
+        // TODO(xla): Implement val updates.
+        let validator_updates = vec![];
+        // TODO(xla): Implement consensus param updates.
+        let consensus_param_updates = None;
+
+        (validator_updates, consensus_param_updates, events)
+    }
+
+    #[instrument(skip(self, storage))]
+    pub async fn commit(&mut self, storage: Storage) -> AppHash {
+        // We need to extract the State we've built up to commit it.  Fill in a dummy state.
+        let dummy_state = StateDelta::new(storage.latest_snapshot());
+        let state = Arc::try_unwrap(std::mem::replace(&mut self.state, Arc::new(dummy_state)))
+            .expect("we have exclusive ownership of the State at commit()");
+
+        // Commit the pending writes, clearing the state.
+        let jmt_root = storage
+            .commit(state)
+            .await
+            .expect("must be able to successfully commit to storage");
+        let app_hash: AppHash = jmt_root.into();
+
+        tracing::debug!(?app_hash, "finished committing state");
+
+        // Get the latest version of the state, now that we've committed it.
+        self.state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+        app_hash
     }
 }

--- a/app/src/component/staking.rs
+++ b/app/src/component/staking.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+use penumbra_storage::StateWrite;
+use pulzaar_chain::genesis::AppState;
+use tendermint::abci::request::{BeginBlock, EndBlock};
+
+use super::ABCIComponent;
+
+#[derive(Default)]
+pub struct Staking {}
+
+#[async_trait]
+impl<S> ABCIComponent<S> for Staking
+where
+    S: StateWrite,
+{
+    async fn init_chain(&self, _state: &mut S, _app_state: &AppState) {
+        todo!()
+    }
+
+    async fn begin_block(&self, _state: &mut S, _begin_blocke: &BeginBlock) {
+        todo!()
+    }
+
+    async fn end_block(&self, _state: &mut S, _end_block: &EndBlock) {
+        todo!()
+    }
+}

--- a/app/src/handler.rs
+++ b/app/src/handler.rs
@@ -1,14 +1,16 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use penumbra_storage::{State, StateTransaction};
+use penumbra_storage::{StateRead, StateWrite};
 use pulzaar_chain::Transaction;
 
+mod input;
 mod transaction;
 
+// TODO(xla): Document.
 #[async_trait]
 pub trait Handler {
     async fn validate(&self, tx: Arc<Transaction>) -> eyre::Result<()>;
-    async fn check(&self, state: Arc<State>) -> eyre::Result<()>;
-    async fn execute<'a>(&self, state: &mut StateTransaction<'a>) -> eyre::Result<()>;
+    async fn check<S: StateRead>(&self, state: Arc<S>) -> eyre::Result<()>;
+    async fn execute<S: StateWrite>(&self, state: &mut S) -> eyre::Result<()>;
 }

--- a/app/src/handler/input.rs
+++ b/app/src/handler/input.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use penumbra_storage::{StateRead, StateWrite};
+use pulzaar_chain::{Input, Transaction};
+
+use crate::handler::Handler;
+
+mod delegate;
+mod undelegate;
+
+#[async_trait]
+impl Handler for Input {
+    async fn validate(&self, tx: Arc<Transaction>) -> eyre::Result<()> {
+        match self {
+            Self::Delegate(input) => input.validate(tx),
+            Self::Undelegate(input) => input.validate(tx),
+        }
+        .await
+    }
+
+    async fn check<S: StateRead>(&self, state: Arc<S>) -> eyre::Result<()> {
+        match self {
+            Self::Delegate(input) => input.check(state),
+            Self::Undelegate(input) => input.check(state),
+        }
+        .await
+    }
+
+    async fn execute<S: StateWrite>(&self, state: &mut S) -> eyre::Result<()> {
+        match self {
+            Self::Delegate(input) => input.execute(state),
+            Self::Undelegate(input) => input.execute(state),
+        }
+        .await
+    }
+}

--- a/app/src/handler/input/delegate.rs
+++ b/app/src/handler/input/delegate.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use penumbra_storage::{StateRead, StateWrite};
+use pulzaar_chain::{input::Delegate, Transaction};
+
+use crate::handler::Handler;
+
+#[async_trait]
+impl Handler for Delegate {
+    async fn validate(&self, _tx: Arc<Transaction>) -> eyre::Result<()> {
+        todo!()
+    }
+
+    async fn check<S: StateRead>(&self, _state: Arc<S>) -> eyre::Result<()> {
+        todo!()
+    }
+
+    async fn execute<S: StateWrite>(&self, _state: &mut S) -> eyre::Result<()> {
+        todo!()
+    }
+}

--- a/app/src/handler/input/undelegate.rs
+++ b/app/src/handler/input/undelegate.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use penumbra_storage::{StateRead, StateWrite};
+use pulzaar_chain::{input::Undelegate, Transaction};
+
+use crate::handler::Handler;
+
+#[async_trait]
+impl Handler for Undelegate {
+    async fn validate(&self, _tx: Arc<Transaction>) -> eyre::Result<()> {
+        todo!()
+    }
+
+    async fn check<S: StateRead>(&self, _state: Arc<S>) -> eyre::Result<()> {
+        todo!()
+    }
+
+    async fn execute<S: StateWrite>(&self, _state: &mut S) -> eyre::Result<()> {
+        todo!()
+    }
+}

--- a/app/src/handler/transaction.rs
+++ b/app/src/handler/transaction.rs
@@ -1,22 +1,36 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use penumbra_storage::{State, StateTransaction};
+use penumbra_storage::{StateRead, StateWrite};
 use pulzaar_chain::Transaction;
 
 use super::Handler;
 
 #[async_trait]
 impl Handler for Transaction {
-    async fn validate(&self, _tx: Arc<Transaction>) -> eyre::Result<()> {
-        todo!()
+    async fn validate(&self, tx: Arc<Transaction>) -> eyre::Result<()> {
+        // TODO(xla): Execute concurretly.
+        for input in self.inputs() {
+            input.validate(tx.clone()).await?;
+        }
+
+        Ok(())
     }
 
-    async fn check(&self, _state: Arc<State>) -> eyre::Result<()> {
-        todo!()
+    async fn check<S: StateRead>(&self, state: Arc<S>) -> eyre::Result<()> {
+        // TODO(xla): Execute concurretly.
+        for input in self.inputs() {
+            input.check(state.clone()).await?;
+        }
+
+        Ok(())
     }
 
-    async fn execute<'a>(&self, _state: &mut StateTransaction<'a>) -> eyre::Result<()> {
-        todo!()
+    async fn execute<S: StateWrite>(&self, state: &mut S) -> eyre::Result<()> {
+        for input in self.inputs() {
+            input.execute(state).await?;
+        }
+
+        Ok(())
     }
 }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,11 +1,21 @@
 [package]
-name                  = "pulzaar-chain"
-version               = "0.1.0"
-authors.workspace     = true
-edition.workspace     = true
-homepage.workspace    = true
-repository.workspace  = true
-publish.workspace     = true
+name                    = "pulzaar-chain"
+version                 = "0.1.0"
+authors.workspace       = true
+edition.workspace       = true
+repository.workspace    = true
+homepage.workspace      = true
+license.workspace       = true
+rust-version.workspace  = true
+publish.workspace       = true
 
 [dependencies]
-serde = { workspace = true, features = [ "derive" ] }
+pulzaar-encoding = { path = "../encoding" }
+
+async-trait       = { workspace = true }
+eyre              = { workspace = true }
+hex               = { workspace = true, features = [ "alloc" ] }
+penumbra-storage  = { workspace = true }
+sha2              = { workspace = true }
+serde             = { workspace = true, features = [ "derive" ] }
+tendermint        = { workspace = true }

--- a/chain/src/app_hash.rs
+++ b/chain/src/app_hash.rs
@@ -1,0 +1,39 @@
+use async_trait::async_trait;
+use penumbra_storage::{RootHash, Snapshot};
+use sha2::{Digest as _, Sha256};
+
+static APPHASH_DOMSEP: &str = "PulzaarAppHash";
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct AppHash(pub [u8; 32]);
+
+#[async_trait]
+pub trait AppHashRead {
+    async fn app_hash(&self) -> eyre::Result<AppHash>;
+}
+
+impl From<RootHash> for AppHash {
+    fn from(value: RootHash) -> Self {
+        let mut h = Sha256::new();
+        h.update(APPHASH_DOMSEP);
+        h.update(value.0);
+
+        AppHash(h.finalize().into())
+    }
+}
+
+impl std::fmt::Debug for AppHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AppHash")
+            .field(&hex::encode(self.0))
+            .finish()
+    }
+}
+
+#[async_trait]
+impl AppHashRead for Snapshot {
+    async fn app_hash(&self) -> eyre::Result<AppHash> {
+        let root = self.root_hash().await.map_err(|err| eyre::eyre!(err))?;
+        Ok(AppHash::from(root))
+    }
+}

--- a/chain/src/input.rs
+++ b/chain/src/input.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 mod delegate;
 mod undelegate;
 
-use delegate::Delegate;
-use undelegate::Undelegate;
+pub use delegate::Delegate;
+pub use undelegate::Undelegate;
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub enum Input {

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -2,15 +2,19 @@
 #![allow(dead_code)]
 
 mod amount;
+mod app_hash;
 mod asset;
 mod fee;
-mod input;
+mod state;
 mod transaction;
 
 pub mod genesis;
+pub mod input;
 
 pub use amount::Amount;
+pub use app_hash::{AppHash, AppHashRead};
 pub use asset::Asset;
 pub use fee::Fee;
 pub use input::Input;
+pub use state::StateWriteExt;
 pub use transaction::Transaction;

--- a/chain/src/state.rs
+++ b/chain/src/state.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+use penumbra_storage::StateWrite;
+use pulzaar_encoding::StateWriteBcs as _;
+use tendermint::Time;
+
+pub fn block_height() -> &'static str {
+    "block_height"
+}
+
+pub fn block_timestamp() -> &'static str {
+    "block_timestamp"
+}
+
+#[async_trait]
+pub trait StateWriteExt: StateWrite {
+    /// Writes the block height to the JMT
+    fn put_block_height(&mut self, height: u64) -> eyre::Result<()> {
+        self.put_bcs(block_height().into(), &height)
+    }
+
+    /// Writes the block timestamp to the JMT
+    fn put_block_timestamp(&mut self, timestamp: Time) -> eyre::Result<()> {
+        self.put_bcs(block_timestamp().into(), &timestamp.to_rfc3339())
+    }
+}
+
+impl<T: StateWrite + ?Sized> StateWriteExt for T {}

--- a/chain/src/transaction.rs
+++ b/chain/src/transaction.rs
@@ -9,6 +9,12 @@ pub struct Transaction {
     // TODO(xla): Figure out signature schemes and layout.
 }
 
+impl Transaction {
+    pub fn inputs(&self) -> impl Iterator<Item = &Input> {
+        self.body.inputs.iter()
+    }
+}
+
 /// Body of a Pulzaar transaction.
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Body {

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
-name                  = "pulzaar-encoding"
-version               = "0.1.0"
-authors.workspace     = true
-edition.workspace     = true
-homepage.workspace    = true
-repository.workspace  = true
-publish.workspace     = true
+name                    = "pulzaar-encoding"
+version                 = "0.1.0"
+authors.workspace       = true
+edition.workspace       = true
+repository.workspace    = true
+homepage.workspace      = true
+license.workspace       = true
+rust-version.workspace  = true
+publish.workspace       = true
 
 [dependencies]
 bcs               = { workspace = true }
@@ -13,10 +15,11 @@ eyre              = { workspace = true }
 futures           = { workspace = true }
 penumbra-storage  = { workspace = true }
 serde             = { workspace = true }
+thiserror         = { workspace = true }
 
 
 [dev-dependencies]
 pretty_assertions = { workspace = true, features = [ "alloc" ] }
-rand              = { workspace = true }
+rand              = { workspace = true, features = [ "std_rng" ] }
 tempfile          = { workspace = true }
 tokio             = { workspace = true, features = [ "macros", "rt", "rt-multi-thread" ] }

--- a/encoding/src/convert.rs
+++ b/encoding/src/convert.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+pub fn from_bytes<'a, T>(bytes: &'a [u8]) -> Result<T, Error>
+where
+    T: Deserialize<'a>,
+{
+    bcs::from_bytes(bytes).map_err(Error::Bcs)
+}
+
+pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>, Error>
+where
+    T: ?Sized + Serialize,
+{
+    bcs::to_bytes(value).map_err(Error::Bcs)
+}

--- a/encoding/src/error.rs
+++ b/encoding/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("encoding failed: {0}")]
+    Bcs(#[from] bcs::Error),
+}

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -1,3 +1,7 @@
+mod convert;
+mod error;
 mod state;
 
+pub use convert::{from_bytes, to_bytes};
+pub use error::Error;
 pub use state::{StateReadBcs, StateWriteBcs};


### PR DESCRIPTION
Completes the implementation of the ABCI interface from the app perspective, which means it can run against a vanilla cometbft node with version `v0.34.x`. All configured components within the app are executed, that list is empty at the moment. An example implementation is included by ways of a `Staking` skeleton, it lacks however any logic and will crash the app if included in the component list.