### PR TITLE
feat(node): Bootstrap node crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +17,15 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -56,6 +71,58 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bcs"
@@ -125,6 +192,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -218,12 +291,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -295,6 +445,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +496,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "errno"
@@ -368,11 +544,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flex-error"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
+ "eyre",
  "paste",
 ]
 
@@ -489,7 +676,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -497,6 +684,47 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "h2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.7",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -520,6 +748,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "ics23"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +878,12 @@ dependencies = [
  "libc",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -618,6 +944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -712,6 +1047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8166fbddef141acbea89cf3425ed97d4c22d14a68161977fc01c301175a4fb89"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,10 +1062,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "metrics"
@@ -733,7 +1107,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142c53885123b68d94108295a09d4afe1a1388ed95b54d5dacd9a454753030f2"
 dependencies = [
  "ahash",
- "metrics-macros",
+ "metrics-macros 0.5.1",
+]
+
+[[package]]
+name = "metrics"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+dependencies = [
+ "ahash",
+ "metrics-macros 0.6.0",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+dependencies = [
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics 0.20.1",
+ "metrics-util",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -748,10 +1151,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "metrics-tracing-context"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6097e2772147f332c9aedba572e9cd334b7946e1762d8ae4d05db0faf962542a"
+dependencies = [
+ "itoa",
+ "lockfree-object-pool",
+ "metrics 0.20.1",
+ "metrics-util",
+ "once_cell",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown",
+ "indexmap",
+ "metrics 0.20.1",
+ "num_cpus",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -761,7 +1227,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
 
@@ -770,6 +1236,15 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nom"
@@ -786,6 +1261,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-derive"
@@ -831,6 +1316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1332,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -877,7 +1377,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "penumbra-storage"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/penumbra?branch=main#74d703297194efc5cabf05c8c088fca0049e28e9"
+source = "git+https://github.com/penumbra-zone/penumbra?branch=main#fe0fe46b623fff46aa37af3cad240f6f3712fdfe"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -886,7 +1386,7 @@ dependencies = [
  "hex",
  "ics23",
  "jmt",
- "metrics",
+ "metrics 0.19.0",
  "parking_lot",
  "pin-project",
  "rocksdb",
@@ -897,6 +1397,12 @@ dependencies = [
  "tokio-stream",
  "tracing",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
@@ -947,6 +1453,12 @@ dependencies = [
  "radicle-cli-test",
  "tempfile",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -1118,6 +1630,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulzaarnode"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "console-subscriber",
+ "directories",
+ "eyre",
+ "futures",
+ "hex",
+ "metrics-exporter-prometheus",
+ "metrics-tracing-context",
+ "metrics-util",
+ "penumbra-storage",
+ "pulzaar-app",
+ "pulzaar-chain",
+ "sha2 0.10.6",
+ "tendermint",
+ "tokio",
+ "tokio-util 0.7.7",
+ "tower-abci",
+ "tower-service",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "quanta"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1712,16 @@ dependencies = [
  "shlex",
  "snapbox",
  "thiserror",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1206,6 +1770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "10.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c307f7aacdbab3f0adee67d52739a1d71112cc068d6fab169ddeb18e48877fad"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,10 +1788,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
  "regex-syntax",
 ]
@@ -1276,6 +1869,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rusty-fork"
@@ -1387,6 +1986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +2026,12 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb945e54128e09c43d8e4f1277851bd5044c6fc540bbaa2ad888f60b3da9ae7"
 
 [[package]]
 name = "slab"
@@ -1499,6 +2113,12 @@ dependencies = [
  "quote 1.0.23",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -1594,11 +2214,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.18"
+name = "thread_local"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+dependencies = [
+ "serde",
  "time-core",
  "time-macros",
 ]
@@ -1611,9 +2242,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -1640,6 +2271,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,12 +2303,144 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.7",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "hdrhistogram",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.7",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-abci"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a278d99d5bd940fcfc82941e75eb6a88c2e3c6ae0f677b97eba7f1dda82087"
+dependencies = [
+ "bytes",
+ "futures",
+ "pin-project",
+ "prost",
+ "tendermint",
+ "tendermint-proto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1691,7 +2464,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -1730,6 +2536,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,10 +2563,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote 1.0.23",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,31 +6,39 @@ members = [
   "chain",
   "config",
   "encoding",
+  "node",
   "plz"
 ]
 
 [workspace.dependencies]
-async-trait       = { version = "0.1",  default-features = false }
-bcs               = { version = "0.1",  default-features = false }
-dialoguer         = { version = "0.10", default-features = false }
-eyre              = { version = "0.6",  default-features = false }
-futures           = { version = "0.3",  default-features = false }
-hex               = { version = "0.4",  default-features = false }
-lexopt            = { version = "0.3",  default-features = false }
-log               = { version = "0.4",  default-features = false }
-penumbra-storage  = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
-pretty_assertions = { version = "1.3",  default-features = false }
-radicle-cli-test  = { version = "0.1" }
-rand              = { version = "0.8",  default-features = false }
-serde             = { version = "1.0",  default-features = false }
-sha2              = { version = "0.10", default-features = false }
-shlex             = { version = "1.1",  default-features = false }
-snapbox           = { version = "0.4",  default-features = false }
-tempfile          = { version = "3.3",  default-features = false }
-tendermint        = { version = "0.26", default-features = false }
-thiserror         = { version = "1.0",  default-features = false }
-tokio             = { version = "1.25", default-features = false }
-tracing           = { version = "0.1",  default-features = false }
+async-trait                 = { version = "0.1",  default-features = false }
+bcs                         = { version = "0.1",  default-features = false }
+bytes                       = { version = "1.0",  default-features = false }
+console-subscriber          = { version = "0.1",  default-features = false }
+dialoguer                   = { version = "0.10", default-features = false }
+directories                 = { version = "4.0",  default-features = false }
+eyre                        = { version = "0.6",  default-features = false }
+futures                     = { version = "0.3",  default-features = false }
+hex                         = { version = "0.4",  default-features = false }
+lexopt                      = { version = "0.3",  default-features = false }
+metrics-exporter-prometheus = { version = "0.11", default-features = false }
+metrics-tracing-context     = { version = "0.12", default-features = false }
+metrics-util                = { version = "0.14", default-features = false }
+penumbra-storage            = { git = "https://github.com/penumbra-zone/penumbra", branch = "main", default-features = false }
+pretty_assertions           = { version = "1.3",  default-features = false }
+radicle-cli-test            = { version = "0.1",  default-features = false }
+rand                        = { version = "0.8",  default-features = false }
+serde                       = { version = "1.0",  default-features = false }
+sha2                        = { version = "0.10", default-features = false }
+tempfile                    = { version = "3.3",  default-features = false }
+tendermint                  = { version = "0.26", default-features = false }
+thiserror                   = { version = "1.0",  default-features = false }
+tokio                       = { version = "1.25", default-features = false }
+tokio-util                  = { version = "0.7",  default-features = false }
+tower-abci                  = { version = "0.2",  default-features = false }
+tower-service               = { version = "0.3",  default-features = false }
+tracing                     = { version = "0.1",  default-features = false }
+tracing-subscriber          = { version = "0.3",  default-features = false }
 
 [workspace.package]
 authors       = ["Pulzaar Team <core@pulzaar.zone>"]
@@ -40,3 +48,8 @@ homepage      = "https://pulzaar.zone"
 repository    = "https://github.com/pulzaar-zone/pulzaar"
 rust-version  = "1.67"
 publish       = false
+
+[profile.release]
+lto       = true
+opt-level = 3
+panic     = "unwind"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name                    = "pulzaarnode"
+version                 = "0.1.0"
+description             = "Pulzaar node reference implementation"
+authors.workspace       = true
+edition.workspace       = true
+repository.workspace    = true
+homepage.workspace      = true
+license.workspace       = true
+rust-version.workspace  = true
+publish.workspace       = true
+
+[dependencies]
+pulzaar-app                 = { path = "../app" }
+pulzaar-chain               = { path = "../chain" }
+
+bytes                       = { workspace = true }
+console-subscriber          = { workspace = true }
+directories                 = { workspace = true }
+eyre                        = { workspace = true }
+futures                     = { workspace = true }
+hex                         = { workspace = true, features = [ "alloc" ] }
+metrics-exporter-prometheus = { workspace = true, features = [ "http-listener" ] }
+metrics-tracing-context     = { workspace = true }
+metrics-util                = { workspace = true }
+penumbra-storage            = { workspace = true }
+sha2                        = { workspace = true }
+tendermint                  = { workspace = true }
+tokio                       = { workspace = true, features = [ "net", "macros", "rt-multi-thread", "tracing" ] }
+tokio-util                  = { workspace = true }
+tower-abci                  = { workspace = true }
+tower-service               = { workspace = true }
+tracing                     = { workspace = true }
+tracing-subscriber          = { workspace = true, features = [ "ansi", "env-filter", "fmt", "registry", "std" ] }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,0 +1,19 @@
+pub const DEFAULT_HOST: &str = "0.0.0.0";
+pub const DEFAULT_ABCI_PORT: &str = "26658";
+pub const DEFAULT_METRICS_PORT: &str = "12121";
+
+pub struct Config {
+    pub host: String,
+    pub abci_port: String,
+    pub metrics_port: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            host: DEFAULT_HOST.to_string(),
+            abci_port: DEFAULT_ABCI_PORT.to_string(),
+            metrics_port: DEFAULT_METRICS_PORT.to_string(),
+        }
+    }
+}

--- a/node/src/consensus.rs
+++ b/node/src/consensus.rs
@@ -1,0 +1,238 @@
+use std::{future::Future, pin::Pin};
+
+use futures::FutureExt as _;
+use penumbra_storage::Storage;
+use pulzaar_app::App;
+use pulzaar_chain::genesis::AppState;
+use tendermint::abci::{self, request, response, ConsensusRequest, ConsensusResponse};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::PollSender;
+use tower_abci::BoxError;
+use tower_service::Service;
+use tracing::{error_span, instrument, Instrument as _, Span};
+
+use crate::RequestExt as _;
+
+#[derive(Debug)]
+struct Message {
+    req: ConsensusRequest,
+    res: oneshot::Sender<ConsensusResponse>,
+    span: Span,
+}
+
+#[derive(Clone)]
+pub struct Consensus {
+    queue: PollSender<Message>,
+}
+
+impl Consensus {
+    pub async fn new(storage: Storage) -> eyre::Result<Self> {
+        let (tx, rx) = mpsc::channel(128);
+
+        tokio::task::Builder::new()
+            .name("consensus::Worker")
+            .spawn(Worker::new(storage, rx).run())
+            .expect("failed to spawn consensus worker");
+
+        Ok(Self {
+            queue: PollSender::new(tx),
+        })
+    }
+}
+
+impl Service<ConsensusRequest> for Consensus {
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<ConsensusResponse, BoxError>> + Send + 'static>>;
+    type Response = ConsensusResponse;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.queue.poll_reserve(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: ConsensusRequest) -> Self::Future {
+        if self.queue.is_closed() {
+            return async move {
+                Err(eyre::eyre!("consensus worker terminated or panicked").into())
+            }.boxed();
+        }
+
+        let span = req.create_span();
+        let span = error_span!(parent: &span, "app", role = "consensus");
+        let (tx, rx) = oneshot::channel();
+
+        self.queue
+            .send_item(Message { req, res: tx, span })
+            .expect("called without poll_ready");
+
+        async move {
+            rx.await
+                .map_err(|_| eyre::eyre!("consensus worker terminated or panicked").into())
+        }
+        .boxed()
+    }
+}
+
+struct Worker {
+    app: App,
+    queue: mpsc::Receiver<Message>,
+    storage: Storage,
+}
+
+impl Worker {
+    #[instrument(skip(storage, queue), name = "consensus::Worker::new")]
+    fn new(storage: Storage, queue: mpsc::Receiver<Message>) -> Self {
+        let app = App::new(storage.latest_snapshot());
+
+        Self {
+            app,
+            queue,
+            storage,
+        }
+    }
+
+    async fn run(mut self) -> eyre::Result<()> {
+        while let Some(Message { req, res, span }) = self.queue.recv().await {
+            let _ = res.send(match req {
+                ConsensusRequest::InitChain(init_chain) => ConsensusResponse::InitChain(
+                    self.init_chain(init_chain)
+                        .instrument(span)
+                        .await
+                        .expect("init_chain failed"),
+                ),
+                ConsensusRequest::BeginBlock(begin_block) => ConsensusResponse::BeginBlock(
+                    self.begin_block(begin_block)
+                        .instrument(span)
+                        .await
+                        .expect("begin_block failed"),
+                ),
+                ConsensusRequest::DeliverTx(deliver_tx) => ConsensusResponse::DeliverTx(
+                    self.deliver_tx(deliver_tx)
+                        .instrument(span)
+                        .await
+                        .expect("deliver_tx failed"),
+                ),
+                ConsensusRequest::EndBlock(end_block) => ConsensusResponse::EndBlock(
+                    self.end_block(end_block)
+                        .instrument(span)
+                        .await
+                        .expect("end_block failed"),
+                ),
+                ConsensusRequest::Commit => ConsensusResponse::Commit(
+                    self.commit().instrument(span).await.expect("commit failed"),
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn init_chain(
+        &mut self,
+        init_chain: request::InitChain,
+    ) -> eyre::Result<response::InitChain> {
+        // TODO(xla): Deserialize app state.
+        let app_state = AppState {};
+
+        // TODO(xla): Error if storage is not at height 0.
+
+        self.app.init_chain(&app_state).await;
+
+        // TODO(xla): Extract validators from app state.
+        let validators = vec![];
+
+        let app_hash = self.app.commit(self.storage.clone()).await;
+
+        tracing::info!(
+            consensus_params = ?init_chain.consensus_params,
+            ?validators,
+            app_hash = ?app_hash,
+            "chain initialized",
+        );
+
+        Ok(response::InitChain {
+            consensus_params: Some(init_chain.consensus_params),
+            validators,
+            app_hash: app_hash.0.to_vec().try_into()?,
+        })
+    }
+
+    async fn begin_block(
+        &mut self,
+        begin_block: request::BeginBlock,
+    ) -> eyre::Result<response::BeginBlock> {
+        tracing::info!(time = ?begin_block.header.time, "beginning block");
+        tracing::trace!(begin_block = ?begin_block);
+
+        let events = self.app.begin_block(&begin_block).await;
+        trace_events(&events);
+
+        Ok(response::BeginBlock { events })
+    }
+
+    async fn deliver_tx(
+        &mut self,
+        deliver_tx: request::DeliverTx,
+    ) -> eyre::Result<response::DeliverTx> {
+        match self.app.deliver_tx_bytes(deliver_tx.tx.as_ref()).await {
+            Ok(events) => {
+                trace_events(&events);
+
+                Ok(response::DeliverTx {
+                    events,
+                    ..Default::default()
+                })
+            },
+            Err(e) => {
+                tracing::debug!(?e, "deliver tx failed");
+
+                Ok(response::DeliverTx {
+                    code: 1,
+                    log: format!("{e:}"),
+                    ..Default::default()
+                })
+            },
+        }
+    }
+
+    async fn end_block(
+        &mut self,
+        end_block: request::EndBlock,
+    ) -> eyre::Result<response::EndBlock> {
+        tracing::info!(height = end_block.height, "ending block");
+
+        let (validator_updates, consensus_param_updates, events) =
+            self.app.end_block(&end_block).await;
+        trace_events(&events);
+
+        Ok(response::EndBlock {
+            validator_updates,
+            consensus_param_updates,
+            events,
+        })
+    }
+
+    async fn commit(&mut self) -> eyre::Result<response::Commit> {
+        let app_hash = self.app.commit(self.storage.clone()).await;
+        tracing::info!(?app_hash, "committed block");
+
+        Ok(response::Commit {
+            data: app_hash.0.to_vec().into(),
+            retain_height: 0u32.into(),
+        })
+    }
+}
+
+fn trace_events(events: &[abci::Event]) {
+    for event in events {
+        let span = tracing::trace_span!("event", kind = event.kind);
+        span.in_scope(|| {
+            for attr in &event.attributes {
+                tracing::trace!(key = attr.key, value = attr.value, index = attr.index);
+            }
+        })
+    }
+}

--- a/node/src/info.rs
+++ b/node/src/info.rs
@@ -1,0 +1,153 @@
+use std::pin::Pin;
+
+use bytes::Bytes;
+use futures::{Future, FutureExt as _};
+use penumbra_storage::Storage;
+use pulzaar_chain::AppHashRead as _;
+use tendermint::abci::{request, response, InfoRequest, InfoResponse};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::PollSender;
+use tower_abci::BoxError;
+use tower_service::Service;
+use tracing::{error_span, instrument, Instrument as _, Span};
+
+use crate::RequestExt as _;
+
+const ABCI_INFO_VERSION: &str = env!("CARGO_PKG_VERSION");
+const APP_VERSION: u64 = 1;
+
+#[derive(Debug)]
+pub struct Message {
+    pub req: InfoRequest,
+    pub res: oneshot::Sender<InfoResponse>,
+    pub span: Span,
+}
+
+#[derive(Clone)]
+pub struct Info {
+    queue: PollSender<Message>,
+}
+
+impl Info {
+    pub async fn new(storage: Storage) -> eyre::Result<Self> {
+        let (tx, rx) = mpsc::channel(128);
+
+        tokio::task::Builder::new()
+            .name("info::Worker")
+            .spawn(Worker::new(storage, rx).run())
+            .expect("failed to spawn info worker");
+
+        Ok(Self {
+            queue: PollSender::new(tx),
+        })
+    }
+}
+
+impl Service<InfoRequest> for Info {
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<InfoResponse, BoxError>> + Send + 'static>>;
+    type Response = InfoResponse;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.queue.poll_reserve(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: InfoRequest) -> Self::Future {
+        if self.queue.is_closed() {
+            return async move { Err(eyre::eyre!("info worker terminated or panicked").into()) }
+                .boxed();
+        }
+
+        let span = req.create_span();
+        let span = error_span!(parent: &span, "app", role = "info");
+        let (tx, rx) = oneshot::channel();
+
+        self.queue
+            .send_item(Message { req, res: tx, span })
+            .expect("called without poll_ready");
+
+        async move {
+            rx.await
+                .map_err(|_| eyre::eyre!("info worker terminated or panicked").into())
+        }
+        .boxed()
+    }
+}
+
+struct Worker {
+    queue: mpsc::Receiver<Message>,
+    storage: Storage,
+}
+
+impl Worker {
+    #[instrument(skip(storage, queue), name = "info::Worker::new")]
+    fn new(storage: Storage, queue: mpsc::Receiver<Message>) -> Self {
+        Self { queue, storage }
+    }
+
+    async fn run(mut self) -> eyre::Result<()> {
+        while let Some(Message { req, res, span }) = self.queue.recv().await {
+            let _ = res.send(match req {
+                InfoRequest::Info(info) => {
+                    InfoResponse::Info(self.info(info).instrument(span).await.expect("info failed"))
+                },
+                InfoRequest::Query(query) => InfoResponse::Query(
+                    self.query(query)
+                        .instrument(span)
+                        .await
+                        .expect("query failed"),
+                ),
+                InfoRequest::Echo(echo) => {
+                    InfoResponse::Echo(self.echo(echo).instrument(span).await.expect("echo failed"))
+                },
+                InfoRequest::SetOption(set_option) => InfoResponse::SetOption(
+                    self.set_option(set_option)
+                        .instrument(span)
+                        .await
+                        .expect("set_option failed"),
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn info(&mut self, info: request::Info) -> eyre::Result<response::Info> {
+        let state = self.storage.latest_snapshot();
+        tracing::info!(?info, version = ?state.version());
+
+        let last_block_height = match state.version() {
+            u64::MAX => 0,
+            v => v,
+        }
+        .try_into()
+        .unwrap();
+        let app_hash = state.app_hash().await?.0.to_vec();
+
+        Ok(response::Info {
+            data: "pulzaar".to_string(),
+            version: ABCI_INFO_VERSION.to_string(),
+            app_version: APP_VERSION,
+            last_block_height,
+            last_block_app_hash: Bytes::from(app_hash),
+        })
+    }
+
+    async fn query(&mut self, _query: request::Query) -> eyre::Result<response::Query> {
+        todo!()
+    }
+
+    async fn echo(&mut self, _echo: request::Echo) -> eyre::Result<response::Echo> {
+        todo!()
+    }
+
+    async fn set_option(
+        &mut self,
+        _set_option: request::SetOption,
+    ) -> eyre::Result<response::SetOption> {
+        todo!()
+    }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,0 +1,15 @@
+mod config;
+mod consensus;
+mod info;
+mod mempool;
+mod request_ext;
+mod run;
+mod snapshot;
+
+pub use config::Config;
+pub use consensus::Consensus;
+pub use info::Info;
+pub use mempool::Mempool;
+pub use request_ext::RequestExt;
+pub use run::run;
+pub use snapshot::Snapshot;

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -1,0 +1,156 @@
+use std::{future::Future, pin::Pin};
+
+use bytes::Bytes;
+use futures::FutureExt as _;
+use penumbra_storage::{Snapshot, Storage};
+use pulzaar_app::App;
+use tendermint::abci::{
+    request::{self, CheckTxKind},
+    response,
+    MempoolRequest,
+    MempoolResponse,
+};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio_util::sync::PollSender;
+use tower_abci::BoxError;
+use tracing::{error_span, instrument, Instrument, Span};
+
+use crate::RequestExt as _;
+
+#[derive(Debug)]
+pub struct Message {
+    pub tx_bytes: Bytes,
+    pub res: oneshot::Sender<eyre::Result<()>>,
+    pub span: Span,
+}
+
+#[derive(Clone)]
+pub struct Mempool {
+    queue: PollSender<Message>,
+}
+
+impl Mempool {
+    pub async fn new(storage: Storage) -> eyre::Result<Self> {
+        let (tx, rx) = mpsc::channel(128);
+
+        tokio::task::Builder::new()
+            .name("mempool::Worker")
+            .spawn(Worker::new(storage, rx).await?.run())
+            .expect("failed to spawn mempool worker");
+
+        Ok(Self {
+            queue: PollSender::new(tx),
+        })
+    }
+}
+
+impl tower_service::Service<MempoolRequest> for Mempool {
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<MempoolResponse, BoxError>> + Send + 'static>>;
+    type Response = MempoolResponse;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.queue.poll_reserve(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: MempoolRequest) -> Self::Future {
+        if self.queue.is_closed() {
+            return async move { Err(eyre::eyre!("mempool worker terminated or panicked").into()) }
+                .boxed();
+        }
+
+        let span = req.create_span();
+        let span = error_span!(parent: &span, "app", role = "mempool");
+        let (tx, rx) = oneshot::channel();
+
+        let MempoolRequest::CheckTx(request::CheckTx { tx: tx_bytes, kind }) = req;
+
+        self.queue
+            .send_item(Message {
+                tx_bytes,
+                res: tx,
+                span: span.clone(),
+            })
+            .expect("called without poll_ready");
+
+        async move {
+            let _kind_str = match kind {
+                CheckTxKind::New => "new",
+                CheckTxKind::Recheck => "recheck",
+            };
+
+            let res = rx.await?;
+
+            match res {
+                Ok(()) => {
+                    tracing::debug!("tx accepted");
+                    // TODO(xla): Add counter in metrics for mempool checktx total.
+
+                    Ok(MempoolResponse::CheckTx(response::CheckTx::default()))
+                },
+                Err(e) => {
+                    tracing::debug!(err = e.to_string(), "tx rejected");
+                    // TODO(xla): Add counter in metrics for mempool checktx total.
+
+                    Ok(MempoolResponse::CheckTx(response::CheckTx {
+                        code: 1,
+                        log: format!("{e:#}"),
+                        ..Default::default()
+                    }))
+                },
+            }
+        }
+        .instrument(span)
+        .boxed()
+    }
+}
+
+struct Worker {
+    app: App,
+    queue: mpsc::Receiver<Message>,
+    snapshot_rx: watch::Receiver<Snapshot>,
+}
+
+impl Worker {
+    #[instrument(skip(storage, queue), name = "mempool::Worker::new")]
+    async fn new(storage: Storage, queue: mpsc::Receiver<Message>) -> eyre::Result<Self> {
+        let app = App::new(storage.latest_snapshot());
+        let snapshot_rx = storage.subscribe();
+
+        Ok(Self {
+            app,
+            queue,
+            snapshot_rx,
+        })
+    }
+
+    pub async fn run(mut self) -> eyre::Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+
+                change = self.snapshot_rx.changed() => {
+                    if let Ok(()) = change {
+                        let state = self.snapshot_rx.borrow().clone();
+                        tracing::debug!(height = ?state.version(), "resetting ephemeral mempool state");
+                        self.app = App::new(state);
+                    } else {
+                        tracing::debug!("state notification channel closed, shutting down");
+                        todo!()
+                    }
+                }
+                message = self.queue.recv() => {
+                    if let Some(Message { tx_bytes, res, span }) = message {
+                        let _ = res.send(self.app.deliver_tx_bytes(tx_bytes.as_ref()).instrument(span).await.map(|_| ()));
+                    } else {
+                        tracing::debug!("message queue closed, shutting down");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/node/src/request_ext.rs
+++ b/node/src/request_ext.rs
@@ -1,0 +1,110 @@
+use sha2::{Digest as _, Sha256};
+use tendermint::abci::{
+    request::{
+        ApplySnapshotChunk,
+        BeginBlock,
+        CheckTx,
+        DeliverTx,
+        EndBlock,
+        InitChain,
+        LoadSnapshotChunk,
+        OfferSnapshot,
+        Query,
+    },
+    ConsensusRequest,
+    InfoRequest,
+    MempoolRequest,
+    SnapshotRequest,
+};
+use tracing::{error_span, Span};
+
+pub trait RequestExt {
+    fn create_span(&self) -> Span;
+}
+
+impl RequestExt for ConsensusRequest {
+    fn create_span(&self) -> Span {
+        let p = error_span!("abci");
+
+        match self {
+            Self::InitChain(InitChain { chain_id, .. }) => {
+                error_span!(parent: &p, "InitChain", ?chain_id)
+            },
+            Self::BeginBlock(BeginBlock { header, .. }) => {
+                error_span!(parent: &p, "BeginBlock", height = ?header.height.value())
+            },
+            Self::DeliverTx(DeliverTx { tx }) => {
+                error_span!(parent: &p, "DeliverTx", tx_id = ?hex::encode(Sha256::digest(tx.as_ref())))
+            },
+            Self::EndBlock(EndBlock { height }) => {
+                error_span!(parent: &p, "EndBlock", ?height)
+            },
+            Self::Commit => {
+                error_span!(parent: &p, "Commit")
+            },
+        }
+    }
+}
+
+impl RequestExt for InfoRequest {
+    fn create_span(&self) -> Span {
+        let p = error_span!("abci");
+
+        match self {
+            Self::Info(_) => error_span!(parent: &p, "Info"),
+            Self::Query(Query {
+                path,
+                height,
+                prove,
+                ..
+            }) => {
+                error_span!(parent: &p, "Query", ?path, ?height, prove)
+            },
+            Self::Echo(_) => error_span!(parent: &p, "Echo"),
+            Self::SetOption(_) => todo!("not implemented"),
+        }
+    }
+}
+
+impl RequestExt for MempoolRequest {
+    fn create_span(&self) -> Span {
+        let p = error_span!("abci");
+
+        match self {
+            Self::CheckTx(CheckTx { kind, tx }) => {
+                error_span!(parent: &p, "CheckTx", ?kind, tx_id = ?hex::encode(Sha256::digest(tx.as_ref())))
+            },
+        }
+    }
+}
+
+impl RequestExt for SnapshotRequest {
+    fn create_span(&self) -> Span {
+        let p = error_span!("abci");
+
+        match self {
+            Self::ListSnapshots => {
+                error_span!(parent: &p, "ListSnapshots")
+            },
+            Self::OfferSnapshot(OfferSnapshot { snapshot, app_hash }) => {
+                error_span!(parent: &p, "OfferSnapshot", app_hash = ?app_hash, height = snapshot.height.value(), chunks = snapshot.chunks)
+            },
+            Self::LoadSnapshotChunk(LoadSnapshotChunk { height, chunk, .. }) => {
+                error_span!(
+                    parent: &p,
+                    "LoadSnapshotChunk",
+                    height = height.value(),
+                    chunk = chunk
+                )
+            },
+            Self::ApplySnapshotChunk(ApplySnapshotChunk { index, sender, .. }) => {
+                error_span!(
+                    parent: &p,
+                    "ApplySnapshotChunk",
+                    index = index,
+                    sender = sender
+                )
+            },
+        }
+    }
+}

--- a/node/src/run.rs
+++ b/node/src/run.rs
@@ -1,0 +1,87 @@
+use std::net::SocketAddr;
+
+use console_subscriber::ConsoleLayer;
+use directories::BaseDirs;
+use eyre::WrapErr as _;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
+use metrics_util::layers::Stack;
+use penumbra_storage::Storage;
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
+
+use crate::{Config, Consensus, Info, Mempool, Snapshot};
+
+pub async fn run(cfg: Config) -> eyre::Result<()> {
+    let dirs = BaseDirs::new().expect("failed to construct base directories");
+
+    let console_layer = ConsoleLayer::builder().with_default_env().spawn();
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .expect("failed to set up env filter");
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(true)
+        .with_thread_ids(true);
+    let metrics_layer = MetricsLayer::new();
+
+    tracing_subscriber::registry()
+        .with(console_layer)
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(metrics_layer)
+        .init();
+
+    let (recorder, exporter) = PrometheusBuilder::new()
+        .with_http_listener(
+            format!("{}:{}", cfg.host, cfg.metrics_port)
+                .parse::<SocketAddr>()
+                .expect("failed to parse metrics addr"),
+        )
+        .build()
+        .expect("failed to build prometheus recorder");
+
+    Stack::new(recorder)
+        .push(TracingContextLayer::only_allow(["chain_id", "role"]))
+        .install()
+        .expect("failed to install recorder");
+
+    tracing::info!("starting pulzaard");
+
+    let storage = Storage::load(dirs.data_dir().join("pulzaar/devnet/pulzaard/rocksdb"))
+        .await
+        .map_err(|e| eyre::eyre!(e))
+        .wrap_err("unable to initialise RocksDB storage")?;
+
+    let consensus = Consensus::new(storage.clone()).await?;
+    let info = Info::new(storage.clone()).await?;
+    let mempool = Mempool::new(storage).await?;
+    let snapshot = Snapshot::new().await?;
+
+    let abci_fut = tower_abci::Server::builder()
+        .consensus(consensus)
+        .mempool(mempool)
+        .snapshot(snapshot)
+        .info(info)
+        .finish()
+        .unwrap()
+        .listen(format!("{}:{}", cfg.host, cfg.abci_port));
+    let abci_server = tokio::task::Builder::new()
+        .name("abci_server")
+        .spawn(abci_fut)
+        .expect("failed to spawn abci server");
+
+    register_metrics();
+
+    tokio::select! {
+        res = exporter => res?,
+        res = abci_server => res?.map_err(|e| eyre::eyre!(e))?,
+    };
+
+    Ok(())
+}
+
+fn register_metrics() {
+    penumbra_storage::register_metrics();
+}

--- a/node/src/snapshot.rs
+++ b/node/src/snapshot.rs
@@ -1,0 +1,147 @@
+use std::{pin::Pin, task::Poll};
+
+use futures::{Future, FutureExt as _};
+use tendermint::abci::{request, response, SnapshotRequest, SnapshotResponse};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::PollSender;
+use tower_abci::BoxError;
+use tower_service::Service;
+use tracing::{error_span, instrument, Instrument as _, Span};
+
+use crate::RequestExt as _;
+
+#[derive(Debug)]
+struct Message {
+    req: SnapshotRequest,
+    res: oneshot::Sender<SnapshotResponse>,
+    span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct Snapshot {
+    queue: PollSender<Message>,
+}
+
+impl Snapshot {
+    pub async fn new() -> eyre::Result<Self> {
+        let (tx, rx) = mpsc::channel(128);
+
+        tokio::task::Builder::new()
+            .name("snapshot::Worker")
+            .spawn(Worker::new(rx).run())
+            .expect("failed to spawn snapshot worker");
+
+        Ok(Self {
+            queue: PollSender::new(tx),
+        })
+    }
+}
+
+impl Service<SnapshotRequest> for Snapshot {
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<SnapshotResponse, BoxError>> + Send + 'static>>;
+    type Response = SnapshotResponse;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: SnapshotRequest) -> Self::Future {
+        if self.queue.is_closed() {
+            return async move {
+                Err(eyre::eyre!("snapshot worker terminated or panicked").into())
+            }.boxed();
+        }
+
+        let span = req.create_span();
+        let span = error_span!(parent: &span, "app", role = "snapshot");
+        let (tx, rx) = oneshot::channel();
+
+        self.queue
+            .send_item(Message { req, res: tx, span })
+            .expect("called without poll_ready");
+
+        async move {
+            rx.await
+                .map_err(|_| eyre::eyre!("snapshot worker terminated or panicked").into())
+        }
+        .boxed()
+    }
+}
+
+struct Worker {
+    queue: mpsc::Receiver<Message>,
+}
+
+impl Worker {
+    #[instrument(skip(queue), name = "snapshot::Worker::new")]
+    fn new(queue: mpsc::Receiver<Message>) -> Self {
+        Self { queue }
+    }
+
+    async fn run(mut self) -> eyre::Result<()> {
+        while let Some(Message { req, res, span }) = self.queue.recv().await {
+            let _ = res.send(match req {
+                SnapshotRequest::ListSnapshots => SnapshotResponse::ListSnapshots(
+                    self.list_snapshots()
+                        .instrument(span)
+                        .await
+                        .expect("list_snapshots failed"),
+                ),
+                SnapshotRequest::OfferSnapshot(offer_snapshot) => SnapshotResponse::OfferSnapshot(
+                    self.offer_snapshot(offer_snapshot)
+                        .instrument(span)
+                        .await
+                        .expect("list_snapshots failed"),
+                ),
+                SnapshotRequest::LoadSnapshotChunk(load_snapshot_chunk) => {
+                    SnapshotResponse::LoadSnapshotChunk(
+                        self.load_snapshot_chunk(load_snapshot_chunk)
+                            .instrument(span)
+                            .await
+                            .expect("list_snapshots failed"),
+                    )
+                },
+                SnapshotRequest::ApplySnapshotChunk(apply_snaphshot_chunk) => {
+                    SnapshotResponse::ApplySnapshotChunk(
+                        self.apply_snapshot_chunk(apply_snaphshot_chunk)
+                            .instrument(span)
+                            .await
+                            .expect("list_snapshots failed"),
+                    )
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn list_snapshots(&mut self) -> eyre::Result<response::ListSnapshots> {
+        todo!()
+    }
+
+    async fn offer_snapshot(
+        &mut self,
+        _offer_snapshot: request::OfferSnapshot,
+    ) -> eyre::Result<response::OfferSnapshot> {
+        todo!()
+    }
+
+    async fn load_snapshot_chunk(
+        &mut self,
+        _load_snapshot_chunk: request::LoadSnapshotChunk,
+    ) -> eyre::Result<response::LoadSnapshotChunk> {
+        todo!()
+    }
+
+    async fn apply_snapshot_chunk(
+        &mut self,
+        _apply_snapshot_chunk: request::ApplySnapshotChunk,
+    ) -> eyre::Result<response::ApplySnapshotChunk> {
+        todo!()
+    }
+}


### PR DESCRIPTION
Set of services on top of tower-abci[^0] to drive the interactions from cometbft through ABCI. There is one service per connection[^1] responsible to drive forward a worker. Every worker wraps an independent instance of `App` for isolation guarantees and improved paralellism.

While it implements a run method which glues together all components, this change-set does not add a binary which has a main, this is left for a follow-up where it can be integrated as command in plz.

[^0]: https://crates.io/crates/tower-abci
[^1]: https://github.com/cometbft/cometbft/blob/main/spec/abci/abci%2B%2B_app_requirements.md#connection-state