### PR TITLE
feat(plz): Add node command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,8 +1450,10 @@ dependencies = [
  "eyre",
  "lexopt",
  "pulzaar-config",
+ "pulzaar-node",
  "radicle-cli-test",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1630,7 +1632,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulzaarnode"
+name = "pulzaar-node"
 version = "0.1.0"
 dependencies = [
  "bytes",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name                    = "pulzaarnode"
+name                    = "pulzaar-node"
 version                 = "0.1.0"
 description             = "Pulzaar node reference implementation"
 authors.workspace       = true

--- a/plz/Cargo.toml
+++ b/plz/Cargo.toml
@@ -13,10 +13,12 @@ path = "src/main.rs"
 
 [dependencies]
 pulzaar-config  = { path = "../config" }
+pulzaar-node    = { path = "../node" }
 
 dialoguer       = { workspace = true }
 eyre            = { workspace = true, features = [ "auto-install" ] }
 lexopt          = { workspace = true }
+tokio           = { workspace = true, features = [ "rt-multi-thread" ] }
 
 [dev-dependencies]
 radicle-cli-test  = { workspace = true }

--- a/plz/src/command.rs
+++ b/plz/src/command.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 
 use crate::config::{DESCRIPTION, GIT_HEAD, NAME, VERSION};
 
+mod node;
+
 #[derive(Debug)]
 pub enum Root {
     Help,
@@ -43,8 +45,9 @@ fn print_version() -> eyre::Result<()> {
     Ok(())
 }
 
-fn run_cmd(cmd: &str, _args: &[OsString]) -> eyre::Result<()> {
+fn run_cmd(cmd: &str, args: &[OsString]) -> eyre::Result<()> {
     match cmd {
+        "node" => node::run(args),
         "version" => print_version(),
 
         _ => Err(eyre::eyre!("\"{cmd}\" is not a supported command")),

--- a/plz/src/command/node.rs
+++ b/plz/src/command/node.rs
@@ -1,0 +1,10 @@
+use std::ffi::OsString;
+
+use tokio::runtime::Runtime;
+
+// TODO(xla): Parse args into pulzaar-node::Config.
+pub fn run(_args: &[OsString]) -> eyre::Result<()> {
+    let rt = Runtime::new()?;
+
+    rt.block_on(pulzaar_node::run(Default::default()))
+}


### PR DESCRIPTION
Use the run method of the node crate to conveniently start a node through the plz cli. Still lacks arg parsing to construct the config struct, which means the node is ran with defaults for now.