### PR TITLE
feat(app): Validate transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,10 +1629,15 @@ dependencies = [
  "eyre",
  "hex",
  "penumbra-storage",
+ "pretty_assertions",
  "pulzaar-chain",
+ "pulzaar-crypto",
  "pulzaar-encoding",
+ "rand",
  "sha2 0.10.6",
+ "tempfile",
  "tendermint",
+ "tokio",
  "tracing",
 ]
 
@@ -1644,6 +1649,7 @@ dependencies = [
  "pulzaar-crypto",
  "pulzaar-encoding",
  "serde",
+ "sha2 0.10.6",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace       = true
 
 [dependencies]
 pulzaar-chain     = { path = "../chain" }
+pulzaar-crypto    = { path = "../crypto" }
 pulzaar-encoding  = { path = "../encoding" }
 
 async-trait       = { workspace = true }
@@ -20,3 +21,9 @@ penumbra-storage  = { workspace = true }
 sha2              = { workspace = true }
 tendermint        = { workspace = true }
 tracing           = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+rand              = { workspace = true, features = [ "std_rng" ] }
+tempfile          = { workspace = true }
+tokio             = { workspace = true, features = [ "macros" ] }

--- a/app/src/component.rs
+++ b/app/src/component.rs
@@ -3,7 +3,8 @@ use penumbra_storage::StateWrite;
 use pulzaar_chain::genesis::AppState;
 use tendermint::abci::request::{BeginBlock, EndBlock};
 
-mod staking;
+pub mod accounts;
+pub mod staking;
 
 pub use staking::Staking;
 

--- a/app/src/component/accounts.rs
+++ b/app/src/component/accounts.rs
@@ -1,0 +1,3 @@
+mod state;
+
+pub use state::AccountsRead;

--- a/app/src/component/accounts/state.rs
+++ b/app/src/component/accounts/state.rs
@@ -1,0 +1,100 @@
+// FIXME(xla): Remove.
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+use pulzaar_chain::Account;
+use pulzaar_crypto::Address;
+use pulzaar_encoding::{StateReadDecode, StateWriteEncode};
+
+use crate::state::StateKey as _;
+
+#[inline]
+fn latest_id_key() -> String {
+    "latest_account_id".to_string()
+}
+
+fn state_key_by_address(address: &Address) -> String {
+    format!("accounts/{}", address.state_key())
+}
+
+#[async_trait]
+pub trait AccountsRead: StateReadDecode {
+    async fn account(&self, address: &Address) -> eyre::Result<Option<Account>> {
+        let key = state_key_by_address(address);
+        self.get_bcs::<Account>(&key).await
+    }
+}
+
+impl<T: StateReadDecode + ?Sized> AccountsRead for T {}
+
+#[async_trait]
+pub trait AccountsWrite: StateWriteEncode {
+    async fn create_account(&mut self, address: Address) -> eyre::Result<()> {
+        let key = state_key_by_address(&address);
+        if self.get_bcs::<Account>(&key).await?.is_some() {
+            return Err(eyre::eyre!("accout exists already"));
+        }
+
+        let id = self.increment_id().await?;
+        let key = state_key_by_address(&address);
+
+        self.put_bcs(
+            key,
+            &Account::Single {
+                address,
+                id,
+                sequence: 0,
+            },
+        )
+    }
+
+    async fn increment_id(&mut self) -> eyre::Result<u64> {
+        let old = self
+            .get_bcs::<u64>(&latest_id_key())
+            .await?
+            .unwrap_or_default();
+        let new = old + 1;
+        self.put_bcs(latest_id_key(), &new)?;
+
+        Ok(new)
+    }
+}
+
+impl<T: StateWriteEncode + ?Sized> AccountsWrite for T {}
+
+#[cfg(test)]
+mod test {
+    use penumbra_storage::{StateDelta, Storage};
+    use pulzaar_crypto::{Address, SigningKey};
+    use rand::thread_rng;
+    use tempfile::tempdir;
+
+    use super::AccountsWrite as _;
+
+    #[tokio::test]
+    async fn create_account() -> eyre::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.into_path();
+        let storage = Storage::load(path.clone())
+            .await
+            .map_err(|e| eyre::eyre!(e))?;
+
+        let mut state = StateDelta::new(storage.latest_snapshot());
+        let mut state_tx = StateDelta::new(&mut state);
+
+        let signer = SigningKey::new(thread_rng());
+        let addr = Address::from(signer.verification_key());
+
+        // First time should succeed.
+        state_tx.create_account(addr.clone()).await?;
+
+        // Subsequent creations for the same address should fail.
+        assert!(state_tx.create_account(addr.clone()).await.is_err());
+
+        state_tx.apply();
+
+        storage.commit(state).await.unwrap();
+
+        Ok(())
+    }
+}

--- a/app/src/handler/input/delegate.rs
+++ b/app/src/handler/input/delegate.rs
@@ -9,7 +9,8 @@ use crate::handler::Handler;
 #[async_trait]
 impl Handler for Delegate {
     async fn validate(&self, _tx: Arc<Transaction>) -> eyre::Result<()> {
-        todo!()
+        // Nothing to assert at this stage.
+        Ok(())
     }
 
     async fn check<S: StateRead>(&self, _state: Arc<S>) -> eyre::Result<()> {

--- a/app/src/handler/transaction.rs
+++ b/app/src/handler/transaction.rs
@@ -2,13 +2,29 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use penumbra_storage::{StateRead, StateWrite};
-use pulzaar_chain::Transaction;
+use pulzaar_chain::{Auth, Transaction};
+use pulzaar_crypto::SignBytes;
 
 use super::Handler;
 
 #[async_trait]
 impl Handler for Transaction {
     async fn validate(&self, tx: Arc<Transaction>) -> eyre::Result<()> {
+        // Ensure there is at least one input in the body.
+        if self.body.inputs.is_empty() {
+            return Err(eyre::eyre!("expected at least one input"));
+        }
+
+        // Verify signature matches expected given the tranaction body as message.
+        let (vk, sig) = match self.auth {
+            Auth::Ed25519 {
+                verification_key: vk,
+                signature: sig,
+            } => (vk, sig),
+        };
+
+        vk.verify(&sig, &tx.body.sign_bytes()?)?;
+
         // TODO(xla): Execute concurretly.
         for input in self.inputs() {
             input.validate(tx.clone()).await?;
@@ -18,6 +34,10 @@ impl Handler for Transaction {
     }
 
     async fn check<S: StateRead>(&self, state: Arc<S>) -> eyre::Result<()> {
+        // TODO(xla): Assert that chain_id matches.
+        // TODO(xla): Asseert max_height is not exceeded.
+        // TODO(xla): Assert account id matches.
+        // TODO(xla): Assert sequence number matches.
         // TODO(xla): Execute concurretly.
         for input in self.inputs() {
             input.check(state.clone()).await?;
@@ -29,6 +49,84 @@ impl Handler for Transaction {
     async fn execute<S: StateWrite>(&self, state: &mut S) -> eyre::Result<()> {
         for input in self.inputs() {
             input.execute(state).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use pulzaar_chain::{input, Auth, Input, Transaction, TransactionBody};
+    use pulzaar_crypto::{SignBytes, SigningKey};
+    use rand::thread_rng;
+
+    use crate::handler::Handler;
+
+    #[tokio::test]
+    async fn validate_inputs_not_empty() -> eyre::Result<()> {
+        let signer = SigningKey::new(thread_rng());
+        let body = TransactionBody {
+            inputs: vec![],
+            chain_id: "test".to_string(),
+            max_height: None,
+            account_id: 0,
+            sequence: 0,
+        };
+        let signature = signer.sign(&body.sign_bytes()?);
+        let tx = Transaction {
+            auth: Auth::Ed25519 {
+                verification_key: signer.verification_key(),
+                signature,
+            },
+            body: body.clone(),
+        };
+
+        let tx = Arc::new(tx);
+        assert!(tx.validate(tx.clone()).await.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validate_signature() -> eyre::Result<()> {
+        let signer = SigningKey::new(thread_rng());
+        let body = TransactionBody {
+            inputs: vec![Input::Delegate(input::Delegate {})],
+            chain_id: "test".to_string(),
+            max_height: None,
+            account_id: 0,
+            sequence: 0,
+        };
+
+        // Valid signature.
+        {
+            let signature = signer.sign(&body.sign_bytes()?);
+            let tx = Transaction {
+                auth: Auth::Ed25519 {
+                    verification_key: signer.verification_key(),
+                    signature,
+                },
+                body: body.clone(),
+            };
+            let tx = Arc::new(tx);
+            tx.validate(tx.clone()).await?;
+        }
+
+        // Invalid signature.
+        {
+            let signature = signer.sign(b"bogus");
+            let tx = Transaction {
+                auth: Auth::Ed25519 {
+                    verification_key: signer.verification_key(),
+                    signature,
+                },
+                body,
+            };
+            let tx = Arc::new(tx);
+            assert!(tx.validate(tx.clone()).await.is_err());
         }
 
         Ok(())

--- a/app/src/state.rs
+++ b/app/src/state.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use penumbra_storage::Snapshot;
+use pulzaar_crypto::Address;
 use pulzaar_encoding::StateWriteEncode;
 use tendermint::Time;
 
@@ -40,3 +41,13 @@ pub trait StateWriteExt: StateWriteEncode {
 }
 
 impl<T: StateWriteEncode + ?Sized> StateWriteExt for T {}
+
+pub trait StateKey {
+    fn state_key(&self) -> String;
+}
+
+impl StateKey for Address {
+    fn state_key(&self) -> String {
+        hex::encode(self)
+    }
+}

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -15,3 +15,4 @@ pulzaar-encoding  = { path = "../encoding" }
 
 eyre              = { workspace = true }
 serde             = { workspace = true, features = [ "derive" ] }
+sha2              = { workspace = true }

--- a/chain/src/input.rs
+++ b/chain/src/input.rs
@@ -11,7 +11,7 @@ pub use undelegate::Undelegate;
 // TODO(xla): Remov this allow, it's only triggered because the other variants carry empty structs
 // at the moment
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum Input {
     // Assets
     Transfer(Transfer),

--- a/chain/src/input/assets.rs
+++ b/chain/src/input/assets.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Funds;
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Transfer {
     from: Address,
     to: Address,

--- a/chain/src/input/delegate.rs
+++ b/chain/src/input/delegate.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
 
 // TODO(xla): Fill out and document.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Delegate {}

--- a/chain/src/input/undelegate.rs
+++ b/chain/src/input/undelegate.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
 
 // TODO(xla): Fill out and document.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Undelegate {}

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -17,4 +17,4 @@ pub use asset::Asset;
 pub use fee::Fee;
 pub use funds::Funds;
 pub use input::Input;
-pub use transaction::Transaction;
+pub use transaction::{Auth, Body as TransactionBody, Transaction};

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -5,15 +5,15 @@ use crate::{Ed25519Error, VerificationKey};
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Address(pub VerificationKey);
 
-impl From<VerificationKey> for Address {
-    fn from(vk: VerificationKey) -> Self {
-        Self(vk)
-    }
-}
-
 impl AsRef<[u8]> for Address {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl From<VerificationKey> for Address {
+    fn from(vk: VerificationKey) -> Self {
+        Self(vk)
     }
 }
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,4 +1,6 @@
 mod address;
+mod sign_bytes;
 
 pub use address::Address;
 pub use ed25519_consensus::{Error as Ed25519Error, Signature, SigningKey, VerificationKey};
+pub use sign_bytes::SignBytes;

--- a/crypto/src/sign_bytes.rs
+++ b/crypto/src/sign_bytes.rs
@@ -1,0 +1,5 @@
+/// Behaviour to produce the bytes expected to be signs for the type in question.
+pub trait SignBytes {
+    /// Returns the bytes to be signed with ['SigningKey`].
+    fn sign_bytes(&self) -> eyre::Result<Vec<u8>>;
+}

--- a/encoding/src/state.rs
+++ b/encoding/src/state.rs
@@ -11,7 +11,7 @@ pub trait StateReadDecode: StateRead + Send + Sync {
     fn get_bcs<'a, T>(
         &self,
         key: &'a str,
-    ) -> Pin<Box<dyn Future<Output = eyre::Result<Option<T>>> + 'a>>
+    ) -> Pin<Box<dyn Future<Output = eyre::Result<Option<T>>> + Send + 'a>>
     where
         T: DeserializeOwned,
     {


### PR DESCRIPTION
Adds two validation rules for transactions:

* assert inputs are not empty
* signature matches given the tx body as input