### PR TITLE
chore(app): Separate query from ABCI component

### DIFF
--- a/app/src/component/accounts.rs
+++ b/app/src/component/accounts.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
-use penumbra_storage::{StateRead, StateWrite};
+use penumbra_storage::StateWrite;
 use pulzaar_chain::genesis::AppState;
-use pulzaar_encoding::{from_bytes, to_bytes, ToBech32 as _};
-use tendermint::abci::{request, response, Code};
+use tendermint::abci::request;
 
-use crate::{component::ABCIComponent, query::Prefix};
+use crate::component::ABCIComponent;
 
-mod query;
+pub mod query;
 mod state;
 
 pub use query::Query;
@@ -16,8 +15,6 @@ pub struct Accounts {}
 
 #[async_trait]
 impl ABCIComponent for Accounts {
-    const QUERY_PREFIX: Option<Prefix> = Some(Prefix::Accounts);
-
     async fn init_chain<S: StateWrite>(&self, state: &mut S, app_state: &AppState) {
         for allocation in &app_state.allocations {
             // FIXME(xla): ABCI does not allow for errors to be returned during chain
@@ -26,37 +23,6 @@ impl ABCIComponent for Accounts {
                 .create_account(allocation.address.clone())
                 .await
                 .unwrap();
-        }
-    }
-
-    async fn query<S: StateRead>(
-        &self,
-        state: &S,
-        query: &request::Query,
-    ) -> eyre::Result<response::Query> {
-        let resp = response::Query {
-            height: query.height,
-            codespace: Self::QUERY_PREFIX.unwrap().to_string(),
-            ..response::Query::default()
-        };
-
-        let accounts_query: Query = from_bytes(&query.data)?;
-
-        match accounts_query {
-            Query::AccountByAddress(address) => Ok(match state.account(&address).await? {
-                Some(account) => response::Query {
-                    code: Code::Ok,
-                    key: address.to_bech32()?.into(),
-                    value: to_bytes(&account)?.into(),
-                    ..resp
-                },
-                None => response::Query {
-                    // TODO(tsenart): Formalize error codes ala https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
-                    code: Code::from(38),
-                    log: "not found".to_string(),
-                    ..resp
-                },
-            }),
         }
     }
 

--- a/app/src/component/accounts/query.rs
+++ b/app/src/component/accounts/query.rs
@@ -1,7 +1,41 @@
-use pulzaar_chain::Address;
+use async_trait::async_trait;
+use pulzaar_chain::{Account, Address};
+use pulzaar_encoding::StateReadDecode;
 use serde::{Deserialize, Serialize};
+
+use crate::{component::accounts::AccountsRead as _, query};
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum Query {
     AccountByAddress(Address),
+}
+
+#[async_trait]
+impl<S> query::Query<S> for Query
+where
+    S: StateReadDecode,
+{
+    type Key = Vec<u8>;
+    type Response = Response;
+
+    async fn respond(&self, state: &S) -> eyre::Result<(Vec<u8>, Response)> {
+        match self {
+            Self::AccountByAddress(address) => {
+                let account = state
+                    .account(address)
+                    .await?
+                    .ok_or(eyre::eyre!("account not found"))?;
+
+                Ok((
+                    pulzaar_encoding::to_bytes(&address)?.to_vec(),
+                    Response::Account(account),
+                ))
+            },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Response {
+    Account(Account),
 }

--- a/app/src/component/assets.rs
+++ b/app/src/component/assets.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use penumbra_storage::{StateRead, StateWrite};
+use penumbra_storage::StateWrite;
 use pulzaar_chain::{genesis::AppState, REGISTRY};
-use tendermint::abci::{request, response};
+use tendermint::abci::request;
 
 use crate::component::ABCIComponent;
 
@@ -28,14 +28,6 @@ impl ABCIComponent for Assets {
                 .put_balance(&allocation.address, &asset.id, allocation.amount)
                 .unwrap();
         }
-    }
-
-    async fn query<S: StateRead>(
-        &self,
-        _state: &S,
-        _req: &request::Query,
-    ) -> eyre::Result<response::Query> {
-        todo!()
     }
 
     async fn begin_block<S: StateWrite>(&self, _state: &mut S, _begin_block: &request::BeginBlock) {

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
+use async_trait::async_trait;
 use eyre::Report;
+use serde::Serialize;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Prefix {
@@ -26,4 +28,12 @@ impl TryFrom<&str> for Prefix {
             _ => Err(eyre::eyre!("unsupported query prefix")),
         }
     }
+}
+
+#[async_trait]
+pub trait Query<S> {
+    type Key: Serialize;
+    type Response: Serialize + Send + Sync;
+
+    async fn respond(&self, state: &S) -> eyre::Result<(Self::Key, Self::Response)>;
 }


### PR DESCRIPTION
This demarcates core ABCI consensus level fuctionality from query functionality in components by separating them into different types with different lifecycles. Attempting to consolidate left us with large unwieldy types when trying to manage them dynamically in the app container.