### PR TITLE
feat(hub): add cors middleware to axum router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "sov-state",
  "sov-test-utils",
  "tempfile",
+ "tower-http 0.6.1",
  "tracing",
 ]
 
@@ -6483,7 +6484,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.5.2",
  "tower-request-id",
  "tracing",
 ]
@@ -6657,7 +6658,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "tower-http",
+ "tower-http 0.5.2",
  "tower-layer",
  "tracing",
 ]
@@ -7450,6 +7451,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,8 @@ tracing-panic             = { version = "0.1.2",    default-features = false }
 tracing-subscriber        = { version = "0.3.17",   default-features = false }
 wasm-bindgen              = { version = "0.2.84",   default-features = false }
 wasm-bindgen-test         = { version = "0.3.34",   default-features = false }
+tower-http                = { version = "0.6.1",    default-features = false }
+
 
 [patch."ssh://git@github.com/Sovereign-Labs/sov-wallet-format.git"]
 sov-wallet-format               = { git = "ssh://git@github.com/filament-zone/sov-wallet-format.git", rev = "44e23f9" }

--- a/crates/modules/core/Cargo.toml
+++ b/crates/modules/core/Cargo.toml
@@ -27,6 +27,7 @@ schemars        = { workspace = true, optional = true }
 serde           = { workspace = true }
 serde_bytes     = { workspace = true }
 tracing         = { workspace = true }
+tower-http      = { workspace = true, features = [ "cors" ]}
 
 [dev-dependencies]
 filament-hub-core = { path = ".", version = "*", features = [ "native" ] }


### PR DESCRIPTION
This PR adds a stricter CORS configuration by allowing requests  from any host.

Question:
Should I move allowed origins to an environment variable for environment-specific control (e.g., production vs. development), or keep it as `Any` to allow all origins by default?